### PR TITLE
Remove dependencies on ros_controllers and gazebo_ros_pkgs metapackages.

### DIFF
--- a/vulcano_gazebo/package.xml
+++ b/vulcano_gazebo/package.xml
@@ -6,7 +6,7 @@
       Gazebo wrapper for the Universal UR5/10 robot arms.
   </description>
 
-  
+
   <author>Alexander Bubeck</author>
   <author email="sedwards@swri.org">Shaun Edwards</author>
   <author email="fxm@ipa.fhg.de">Felix Messmer</author>
@@ -18,15 +18,13 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <run_depend>vulcano_description</run_depend>
-  <run_depend>gazebo_ros_pkgs</run_depend>
   <run_depend>gazebo_ros</run_depend>
   <run_depend>gazebo_ros_control</run_depend>
-  <run_depend>ros_controllers</run_depend>
   <run_depend>joint_state_controller</run_depend>
   <run_depend>joint_trajectory_controller</run_depend>
   <run_depend>effort_controllers</run_depend>
   <run_depend>robot_state_publisher</run_depend>
-  
+
 
   <export>
   </export>

--- a/vulcano_torso_gazebo/package.xml
+++ b/vulcano_torso_gazebo/package.xml
@@ -6,7 +6,7 @@
       Gazebo wrapper for the Universal UR5/10 robot arms.
   </description>
 
-  
+
   <author>Marc Bosch-Jorge</author>
   <author email="mbosch@robotnik.es">Marc Bosch-Jorge</author>
   <maintainer email="mbosch@robotnik.es">Marc Bosch-Jorge</maintainer>
@@ -17,15 +17,13 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <run_depend>vulcano_description</run_depend>
-  <run_depend>gazebo_ros_pkgs</run_depend>
   <run_depend>gazebo_ros</run_depend>
   <run_depend>gazebo_ros_control</run_depend>
-  <run_depend>ros_controllers</run_depend>
   <run_depend>joint_state_controller</run_depend>
   <run_depend>joint_trajectory_controller</run_depend>
   <run_depend>effort_controllers</run_depend>
   <run_depend>robot_state_publisher</run_depend>
-  
+
 
   <export>
   </export>


### PR DESCRIPTION
As per http://www.ros.org/reps/rep-0127.html, packages are not allowed to
depend on metapackages.